### PR TITLE
perf: render Image in SSR and use srcset for lighter payloads

### DIFF
--- a/src/components/app/image.tsx
+++ b/src/components/app/image.tsx
@@ -1,8 +1,10 @@
-import { useState, useEffect, type FC, type ImgHTMLAttributes } from "react";
+import { useMemo, useRef, type FC, type ImgHTMLAttributes } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
-import buildImageUrl from "@/lib/build-image-url";
+import buildImageUrl, { buildSrcSet } from "@/lib/build-image-url";
 import type { ImageQuality } from "@/lib/build-image-url";
-import { useIntersectionObserver } from "@uidotdev/usehooks";
+import { cn } from "@/lib/utils";
+
+export type ImagePriority = "high" | "low" | "auto";
 
 export type ImageProps = {
   quality?: ImageQuality;
@@ -10,7 +12,10 @@ export type ImageProps = {
   width?: number;
   height?: number;
   alt?: string;
+  /** @deprecated use priority="high" */
   eager?: boolean;
+  priority?: ImagePriority;
+  sizes?: string;
 } & ImgHTMLAttributes<HTMLImageElement>;
 
 export const Image: FC<ImageProps> = ({
@@ -20,74 +25,79 @@ export const Image: FC<ImageProps> = ({
   quality = "medium",
   unoptimized = false,
   alt = "",
-  eager = false,
+  eager,
+  priority,
+  sizes,
+  className,
+  style,
+  onLoad,
+  onError,
   ...props
 }) => {
-  const [loading, setLoading] = useState(!eager);
-  const [imgRef, isIntersecting] = useIntersectionObserver<HTMLImageElement>({
-    rootMargin: "200px",
-    threshold: 0,
-  });
-
-  const aspectRatio = (height / width) * 100;
-
+  const effectivePriority: ImagePriority = priority ?? (eager ? "high" : "auto");
   const imageSrc = src || `https://via.placeholder.com/${width}x${height}`;
-  const url = unoptimized ? imageSrc : buildImageUrl(imageSrc, width, quality);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: set loading to true when url changes
-  useEffect(() => {
-    setLoading(!eager);
-  }, [url]);
+  const { url, srcSet } = useMemo(() => {
+    if (unoptimized) return { url: imageSrc, srcSet: undefined };
+    return {
+      url: buildImageUrl(imageSrc, width, quality),
+      srcSet: buildSrcSet(imageSrc, width, quality),
+    };
+  }, [imageSrc, width, quality, unoptimized]);
 
-  const shouldLoad = eager || isIntersecting;
+  const erroredRef = useRef(false);
 
   return (
     <div
-      ref={imgRef}
       style={{
         position: "relative",
         width: "100%",
-        paddingTop: `${aspectRatio}%`,
+        aspectRatio: `${width} / ${height}`,
         overflow: "hidden",
+        ...style,
       }}
     >
-      <Skeleton
+      <img
+        ref={(img) => {
+          if (img && img.complete && img.naturalWidth > 0) {
+            img.dataset.loaded = "true";
+          }
+        }}
+        src={url}
+        srcSet={srcSet}
+        sizes={sizes ?? `${width}px`}
+        width={width}
+        height={height}
+        alt={alt}
+        loading={effectivePriority === "high" ? "eager" : "lazy"}
+        decoding={effectivePriority === "high" ? "sync" : "async"}
+        fetchPriority={effectivePriority === "auto" ? undefined : effectivePriority}
+        className={cn("egd-image", className)}
         style={{
           position: "absolute",
-          top: 0,
-          left: 0,
+          inset: 0,
           width: "100%",
           height: "100%",
-          transition: "opacity 0.5s ease",
-          opacity: loading ? 1 : 0,
-          zIndex: loading ? 1 : -1,
+          objectFit: "cover",
         }}
+        onLoad={(e) => {
+          e.currentTarget.dataset.loaded = "true";
+          onLoad?.(e);
+        }}
+        onError={(e) => {
+          if (!erroredRef.current) {
+            erroredRef.current = true;
+            e.currentTarget.src = imageSrc;
+          }
+          e.currentTarget.dataset.loaded = "true";
+          onError?.(e);
+        }}
+        {...props}
       />
-      {shouldLoad && (
-        <picture style={{ opacity: loading ? 0 : 1, transition: "opacity 0.5s ease" }}>
-          <img
-            src={url}
-            width={width}
-            height={height}
-            style={{
-              position: "absolute",
-              top: 0,
-              left: 0,
-              width: "100%",
-              height: "100%",
-              objectFit: "cover",
-            }}
-            onLoad={() => setLoading(false)}
-            onError={(e) => {
-              setLoading(false);
-              e.currentTarget.src = imageSrc;
-            }}
-            loading={eager ? "eager" : "lazy"}
-            {...props}
-            alt={alt}
-          />
-        </picture>
-      )}
+      <Skeleton
+        className="egd-image-skeleton"
+        style={{ position: "absolute", inset: 0, pointerEvents: "none" }}
+      />
     </div>
   );
 };

--- a/src/lib/build-image-url.ts
+++ b/src/lib/build-image-url.ts
@@ -1,6 +1,24 @@
 export type ImageQuality = "original" | "low" | "medium" | "high";
 
-export default (src: string, height: number, quality: ImageQuality = "medium") =>
-  src.startsWith("http") || src.startsWith("//")
-    ? `${src}?w=${height}&quality=${quality}&resize=1`
-    : "/placeholder.webp";
+const isAbsolute = (src: string) => src.startsWith("http") || src.startsWith("//");
+
+const buildImageUrl = (src: string, width: number, quality: ImageQuality = "medium") =>
+  isAbsolute(src) ? `${src}?w=${width}&quality=${quality}&resize=1` : "/placeholder.webp";
+
+export default buildImageUrl;
+
+const DPR_MULTIPLIERS = [1, 1.5, 2];
+
+export const buildSrcSet = (
+  src: string,
+  width: number,
+  quality: ImageQuality = "medium",
+): string | undefined => {
+  if (!isAbsolute(src)) return undefined;
+  const widths = DPR_MULTIPLIERS
+    .map((m) => Math.round(width * m))
+    .filter((w, i, arr) => arr.indexOf(w) === i);
+  return widths
+    .map((w) => `${src}?w=${w}&quality=${quality}&resize=1 ${w}w`)
+    .join(", ");
+};

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -37,6 +37,7 @@ import {
 import { Sparkles, TrendingUp } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Image } from "@/components/app/image";
+import buildImageUrl, { buildSrcSet } from "@/lib/build-image-url";
 import { getImage } from "@/lib/get-image";
 import { getOfferOverview } from "@/queries/offer-overview";
 import { formatTimeToHumanReadable } from "@/lib/time-to-human-readable";
@@ -336,10 +337,13 @@ function BuildHoverCard({
       {displayUrl && (
         <div className="w-full h-44 flex-shrink-0 relative">
           <img
-            src={displayUrl}
+            src={buildImageUrl(displayUrl, 320)}
+            srcSet={buildSrcSet(displayUrl, 320)}
+            sizes="320px"
             alt={build.item?.title ?? "Unknown Build"}
             className="w-full h-full object-cover"
             loading="lazy"
+            decoding="async"
           />
         </div>
       )}
@@ -709,11 +713,15 @@ function RouteComponent() {
                 className="w-[32px] h-[42px] sm:w-[40px] sm:h-[52px]"
               >
                 <img
-                  src={
+                  src={buildImageUrl(
                     getImage(g.keyImages, ["DieselGameBoxTall", "OfferImageTall"])?.url ??
-                    "/placeholder.webp"
-                  }
+                      "/placeholder.webp",
+                    80,
+                    "low",
+                  )}
                   alt={g.title}
+                  loading="lazy"
+                  decoding="async"
                   className="w-[32px] h-[42px] sm:w-[40px] sm:h-[52px]"
                 />
               </Link>,
@@ -755,13 +763,17 @@ function RouteComponent() {
                                 className="flex items-center gap-3 p-3 border rounded-lg bg-card transition-colors hover:border-gray-400"
                               >
                                 <img
-                                  src={
+                                  src={buildImageUrl(
                                     getImage(offer.keyImages, [
                                       "DieselGameBoxTall",
                                       "OfferImageTall",
-                                    ])?.url ?? "/placeholder.webp"
-                                  }
+                                    ])?.url ?? "/placeholder.webp",
+                                    96,
+                                    "low",
+                                  )}
                                   alt={offer.title}
+                                  loading="lazy"
+                                  decoding="async"
                                   className="w-12 h-16 object-cover rounded"
                                 />
                                 <div className="flex-1">
@@ -841,11 +853,15 @@ function RouteComponent() {
                 className="w-[32px] h-[42px] sm:w-[40px] sm:h-[52px]"
               >
                 <img
-                  src={
+                  src={buildImageUrl(
                     getImage(o.keyImages, ["DieselGameBoxTall", "OfferImageTall"])?.url ??
-                    "/placeholder.webp"
-                  }
+                      "/placeholder.webp",
+                    80,
+                    "low",
+                  )}
                   alt={o.title}
+                  loading="lazy"
+                  decoding="async"
                   className="w-[32px] h-[42px] sm:w-[40px] sm:h-[52px]"
                 />
               </Link>,
@@ -891,11 +907,15 @@ function RouteComponent() {
                 className="w-[32px] h-[42px] sm:w-[40px] sm:h-[52px]"
               >
                 <img
-                  src={
+                  src={buildImageUrl(
                     getImage(o.keyImages, ["DieselGameBoxTall", "OfferImageTall"])?.url ??
-                    "/placeholder.webp"
-                  }
+                      "/placeholder.webp",
+                    80,
+                    "low",
+                  )}
                   alt={o.title}
+                  loading="lazy"
+                  decoding="async"
                   className="w-[32px] h-[42px] sm:w-[40px] sm:h-[52px]"
                 />
               </Link>,
@@ -942,11 +962,15 @@ function RouteComponent() {
                 className="w-[32px] h-[42px] sm:w-[40px] sm:h-[52px]"
               >
                 <img
-                  src={
+                  src={buildImageUrl(
                     getImage(u.keyImages, ["DieselGameBoxTall", "OfferImageTall"])?.url ??
-                    "/placeholder.webp"
-                  }
+                      "/placeholder.webp",
+                    80,
+                    "low",
+                  )}
                   alt={u.title}
+                  loading="lazy"
+                  decoding="async"
                   className="w-[32px] h-[42px] sm:w-[40px] sm:h-[52px]"
                 />
               </Link>,
@@ -1023,11 +1047,15 @@ function RouteComponent() {
                   className="w-[32px] h-[42px] sm:w-[40px] sm:h-[52px]"
                 >
                   <img
-                    src={
+                    src={buildImageUrl(
                       getImage(a.keyImages, ["DieselGameBoxTall", "OfferImageTall"])?.url ??
-                      "/placeholder.webp"
-                    }
+                        "/placeholder.webp",
+                      80,
+                      "low",
+                    )}
                     alt={a.title}
+                    loading="lazy"
+                    decoding="async"
                     className="w-[32px] h-[42px] sm:w-[40px] sm:h-[52px]"
                   />
                 </Link>,
@@ -1084,11 +1112,15 @@ function RouteComponent() {
                 className="w-[32px] h-[42px] sm:w-[40px] sm:h-[52px]"
               >
                 <img
-                  src={
+                  src={buildImageUrl(
                     getImage(t.keyImages, ["DieselGameBoxTall", "OfferImageTall"])?.url ??
-                    "/placeholder.webp"
-                  }
+                      "/placeholder.webp",
+                    80,
+                    "low",
+                  )}
                   alt={t.title}
+                  loading="lazy"
+                  decoding="async"
                   className="w-[32px] h-[42px] sm:w-[40px] sm:h-[52px]"
                 />
               </Link>,
@@ -1121,11 +1153,15 @@ function RouteComponent() {
                 className="w-[32px] h-[42px] sm:w-[40px] sm:h-[52px]"
               >
                 <img
-                  src={
+                  src={buildImageUrl(
                     getImage(b.item?.keyImages ?? [], ["DieselGameBoxTall", "OfferImageTall"])
-                      ?.url ?? "/placeholder.webp"
-                  }
+                      ?.url ?? "/placeholder.webp",
+                    80,
+                    "low",
+                  )}
                   alt={b.item?.title ?? "Unknown Build"}
+                  loading="lazy"
+                  decoding="async"
                   className="w-[32px] h-[42px] sm:w-[40px] sm:h-[52px]"
                 />
               </Link>,

--- a/src/styles.css
+++ b/src/styles.css
@@ -347,3 +347,19 @@ body {
     transform: scale(1) rotate(0deg);
   }
 }
+
+.egd-image {
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+.egd-image[data-loaded="true"] {
+  opacity: 1;
+}
+.egd-image-skeleton {
+  transition: opacity 0.3s ease;
+}
+.egd-image[data-loaded="true"] ~ .egd-image-skeleton {
+  opacity: 0;
+  pointer-events: none;
+}
+


### PR DESCRIPTION
## Summary

- Rewrite `src/components/app/image.tsx` so the `<img>` ships in SSR HTML from first paint instead of being gated behind a per-instance IntersectionObserver. Adds native `srcset` (DPR-aware), `decoding`, and a 3-state `priority` prop mapped to `fetchpriority`. Loading skeleton fades via CSS sibling rule keyed off a `data-loaded` attribute — no React state churn when grids load.
- Add `buildSrcSet` helper in `src/lib/build-image-url.ts` (additive; existing default export unchanged).
- Optimize 8 raw `<img>` thumbnails in `src/routes/index.tsx` home tables that were fetching full-size originals into 32–40px slots — now `?w=80&quality=low` with `loading="lazy"` + `decoding="async"`. The build hover card preview also gets srcset.

## Why

Each `Image` instance created its own `IntersectionObserver` and gated rendering of the `<img>` element behind it. On dense pages (search dropdown, collections, achievements grid, home tables) this meant:

1. SSR HTML contained zero `<img>` tags — the browser preloader couldn't discover, decode, or paint anything until JS hydrated. Bad LCP.
2. N images = N observers + N callbacks firing on scroll — meaningful main-thread cost.
3. `useEffect` reset `loading` on every URL change and `setLoading(false)` from each `onLoad` triggered re-render storms when many images loaded at once.
4. Native `loading="lazy"` was already on the `<img>` — the observer was mostly redundant.

## Backward compatibility

API-compatible — the legacy `eager` prop maps to `priority="high"`. All 15 existing call sites compile and behave the same.

## Test plan

- [ ] `pnpm tsc --noEmit` clean (verified locally).
- [ ] `pnpm dev` and view-source on `/` — confirm `<img src srcset sizes loading decoding>` is present in raw SSR HTML for grid items (today they are absent).
- [ ] DevTools Network tab — confirm srcset candidate selection matches viewport × DPR; confirm hero image priority is High.
- [ ] React Profiler on a heavy grid — confirm no commits fire from image `onLoad` events (skeleton fade is CSS-only).
- [ ] Lighthouse on `/` and `/collections/$id` — measure LCP/TBT/CLS deltas.
- [ ] Cached-nav test: navigate away and back to `/`; images should appear without skeleton flash (validates the `img.complete` ref-callback fix for the cached-image race).
- [ ] Error fallback test: temporarily break a `src`; confirm the fallback fires once and doesn't loop.
- [ ] `pnpm test:e2e` for regression catch.

## Notes for reviewer

- The most subtle correctness detail is the ref callback (`if (img.complete && img.naturalWidth > 0) img.dataset.loaded = "true"`). Without it, a fast cache hit can fire `load` before React attaches the listener, leaving the image at `opacity: 0` forever.
- `decoding="sync"` for `priority="high"` is intentional (paint hero on the same frame as the rest). If TBT regresses on Lighthouse, this is the knob to flip back to `"async"`.
- `buildSrcSet` emits widths derived from the base prop (1×/1.5×/2×). Backend supports arbitrary `?w=` per CLAUDE.md confirmation, but worth a spot check that the CDN cache-keys properly on `w`.
- `<picture>` wrapper was removed — confirmed nothing reads or styles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)