### PR TITLE
fix: hero image hover opacity + throttle offer rAF blur loops

### DIFF
--- a/src/components/app/global-background.tsx
+++ b/src/components/app/global-background.tsx
@@ -31,27 +31,32 @@ export function GlobalBackground() {
     : null;
 
   useEffect(() => {
+    if (!isHovered || !canvasRef?.current || !localCanvasRef.current) return;
+
+    const canvas = localCanvasRef.current;
+    const sourceCanvas = canvasRef.current;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    // Throttle to ~30fps. CSS `blur-3xl + brightness-[0.30]` already smooths
+    // the output; running at full vsync just doubles the per-frame canvas
+    // copy work that's happening upstream in OfferHero.
+    const FRAME_INTERVAL_MS = 1000 / 30;
+    let lastDrawAt = 0;
     let animationFrameId: number;
 
-    const drawFrame = () => {
-      const canvas = localCanvasRef.current;
-      const ctx = canvas?.getContext("2d");
-      if (ctx && canvas && canvasRef?.current) {
-        ctx.drawImage(canvasRef.current, 0, 0, canvas.width, canvas.height);
-        ctx.filter = "blur(1px)";
-        ctx.drawImage(canvas, 0, 0);
+    const drawFrame = (now: number) => {
+      if (now - lastDrawAt >= FRAME_INTERVAL_MS) {
+        ctx.drawImage(sourceCanvas, 0, 0, canvas.width, canvas.height);
+        lastDrawAt = now;
       }
       animationFrameId = requestAnimationFrame(drawFrame);
     };
 
-    if (isHovered && canvasRef?.current) {
-      drawFrame();
-    }
+    animationFrameId = requestAnimationFrame(drawFrame);
 
     return () => {
-      if (animationFrameId) {
-        cancelAnimationFrame(animationFrameId);
-      }
+      cancelAnimationFrame(animationFrameId);
     };
   }, [isHovered, canvasRef]);
 

--- a/src/components/app/image.tsx
+++ b/src/components/app/image.tsx
@@ -49,6 +49,7 @@ export const Image: FC<ImageProps> = ({
 
   return (
     <div
+      className="egd-image-wrap"
       style={{
         position: "relative",
         width: "100%",
@@ -60,7 +61,7 @@ export const Image: FC<ImageProps> = ({
       <img
         ref={(img) => {
           if (img && img.complete && img.naturalWidth > 0) {
-            img.dataset.loaded = "true";
+            img.parentElement?.setAttribute("data-loaded", "true");
           }
         }}
         src={url}
@@ -72,7 +73,7 @@ export const Image: FC<ImageProps> = ({
         loading={effectivePriority === "high" ? "eager" : "lazy"}
         decoding={effectivePriority === "high" ? "sync" : "async"}
         fetchPriority={effectivePriority === "auto" ? undefined : effectivePriority}
-        className={cn("egd-image", className)}
+        className={className}
         style={{
           position: "absolute",
           inset: 0,
@@ -81,7 +82,7 @@ export const Image: FC<ImageProps> = ({
           objectFit: "cover",
         }}
         onLoad={(e) => {
-          e.currentTarget.dataset.loaded = "true";
+          e.currentTarget.parentElement?.setAttribute("data-loaded", "true");
           onLoad?.(e);
         }}
         onError={(e) => {
@@ -89,7 +90,7 @@ export const Image: FC<ImageProps> = ({
             erroredRef.current = true;
             e.currentTarget.src = imageSrc;
           }
-          e.currentTarget.dataset.loaded = "true";
+          e.currentTarget.parentElement?.setAttribute("data-loaded", "true");
           onError?.(e);
         }}
         {...props}

--- a/src/components/app/offer-hero.tsx
+++ b/src/components/app/offer-hero.tsx
@@ -48,34 +48,31 @@ export function OfferHero({ offer }: { offer: SingleOffer }) {
   }, [setCanvasRef]);
 
   useEffect(() => {
-    let animationFrameId: number;
+    if (!isHovered || !videoRef.current || !localCanvasRef.current) return;
 
-    const drawFrame = () => {
-      if (videoRef.current && localCanvasRef.current) {
-        const ctx = localCanvasRef.current.getContext("2d");
-        if (ctx) {
-          ctx.drawImage(
-            videoRef.current,
-            0,
-            0,
-            localCanvasRef.current.width,
-            localCanvasRef.current.height,
-          );
-          ctx.filter = "blur(10px)"; // Apply blur effect
-          ctx.drawImage(localCanvasRef.current, 0, 0);
-        }
+    let animationFrameId: number;
+    const canvas = localCanvasRef.current;
+    const video = videoRef.current;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    // Throttle to ~30fps — the consumer (GlobalBackground) applies blur-3xl
+    // via CSS, so higher refresh rates are imperceptible and just burn CPU.
+    const FRAME_INTERVAL_MS = 1000 / 30;
+    let lastDrawAt = 0;
+
+    const drawFrame = (now: number) => {
+      if (now - lastDrawAt >= FRAME_INTERVAL_MS) {
+        ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+        lastDrawAt = now;
       }
       animationFrameId = requestAnimationFrame(drawFrame);
     };
 
-    if (isHovered && videoRef.current && localCanvasRef.current) {
-      drawFrame();
-    }
+    animationFrameId = requestAnimationFrame(drawFrame);
 
     return () => {
-      if (animationFrameId) {
-        cancelAnimationFrame(animationFrameId);
-      }
+      cancelAnimationFrame(animationFrameId);
     };
   }, [isHovered]);
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -348,17 +348,10 @@ body {
   }
 }
 
-.egd-image {
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-.egd-image[data-loaded="true"] {
-  opacity: 1;
-}
 .egd-image-skeleton {
   transition: opacity 0.3s ease;
 }
-.egd-image[data-loaded="true"] ~ .egd-image-skeleton {
+.egd-image-wrap[data-loaded="true"] > .egd-image-skeleton {
   opacity: 0;
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary

Two fixes on top of #18.

**1. Hero image not hiding on hover (regression from #18).** The previous PR added `.egd-image[data-loaded=\"true\"] { opacity: 1 }` directly to the `<img>` element. That selector has specificity (0,2,0) — class + attribute — which beats Tailwind's `opacity-0` (0,1,0) that callers pass via `className`. On `/offers/$id`, `OfferHero` toggles `opacity-0` on hover to reveal the trailer video underneath, but the image was locked at opacity 1 and kept covering the video.

Fix: move `data-loaded` onto the wrapper `<div className=\"egd-image-wrap\">` and only fade the skeleton via a wrapper-scoped child selector. The `<img>` carries no opacity rule from us anymore, so caller classes work normally. Trade-off: image no longer fades in via CSS — it appears when pixels arrive while the skeleton fades out. Visually the cross-fade is still there.

**2. Hover lag on `/offers/$id` (pre-existing).** Two `requestAnimationFrame` loops run at full vsync rate while hovered (offer-hero feeds a hidden 720×480 canvas, global-background copies it to a second 720×480 canvas):
- Both apply `ctx.filter = \"blur(...)\"` self-blur passes on CPU.
- Both consumers display the canvas through `blur-3xl` Tailwind classes — GPU-accelerated and free, and so much stronger than the JS blur that the JS blur is essentially invisible.
- No frame-rate cap → on a 144Hz monitor that's 144 canvas copies + 144 CPU blurs per second, doubled across the two loops.

Fix: drop the `ctx.filter` self-blur step (CSS already blurs the consumer), cache `getContext(\"2d\")` outside the loop, throttle to ~30fps via a timestamp delta. Roughly a 5× reduction in canvas work per second on a 144Hz display while hovering, plus elimination of the heaviest per-frame op.

## Files

- `src/components/app/image.tsx` — wrapper-level `data-loaded`, `<img>` no longer gets an `egd-image` class.
- `src/styles.css` — replace four rules with two (skeleton-only fade, scoped to the wrapper).
- `src/components/app/offer-hero.tsx` — drop CPU blur, cache ctx, throttle to 30fps.
- `src/components/app/global-background.tsx` — same treatment.

## Test plan

- [ ] On `/offers/$id`, hover the hero — trailer video should fade in and image should fade out (no longer blocked by image).
- [ ] On `/offers/$id`, hover the hero — CPU usage should drop noticeably (compare before/after in Performance tab).
- [ ] On any page with images — skeleton fade-out on load still works.
- [ ] Cached navigation back to a page with images — no skeleton flash (the `img.complete` ref-callback fix from #18 still works because we now walk up to set the wrapper attribute).
- [ ] `pnpm tsc --noEmit` clean (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)