### PR TITLE
fix(security): allow analytics, better-auth, and extensions in CSP

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,11 +26,11 @@ export default defineConfig({
           headers: {
             "Content-Security-Policy": [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-inline' https://analytics.egdata.app https://insights.egdata.app https://*.sentry.io",
-              "style-src 'self' 'unsafe-inline' https://cdn.egdata.app",
-              "img-src 'self' data: blob: https:",
-              "font-src 'self' data: https://cdn.egdata.app",
-              "connect-src 'self' https://api.egdata.app https://cdn.egdata.app https://analytics.egdata.app https://insights.egdata.app https://*.sentry.io https://*.ingest.sentry.io",
+              "script-src 'self' 'unsafe-inline' https://analytics.egdata.app https://insights.egdata.app https://*.sentry.io https://www.googletagmanager.com https://analytics.ahrefs.com https://static.cloudflareinsights.com chrome-extension: moz-extension:",
+              "style-src 'self' 'unsafe-inline' https://cdn.egdata.app chrome-extension: moz-extension:",
+              "img-src 'self' data: blob: https: chrome-extension: moz-extension:",
+              "font-src 'self' data: https://cdn.egdata.app chrome-extension: moz-extension:",
+              "connect-src 'self' https://api.egdata.app https://cdn.egdata.app https://analytics.egdata.app https://insights.egdata.app https://*.sentry.io https://*.ingest.sentry.io https://kv.better-auth.com https://www.google-analytics.com https://*.analytics.google.com https://analytics.ahrefs.com https://cloudflareinsights.com chrome-extension: moz-extension:",
               "media-src 'self' https://cdn.egdata.app https://cdn1.epicgames.com",
               "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com",
               "worker-src 'self' blob:",


### PR DESCRIPTION
## Summary
- The CSP added in #23 blocks several runtime-required third parties: Google Analytics (`googletagmanager.com`), Ahrefs (`analytics.ahrefs.com`), Cloudflare Insights (`static.cloudflareinsights.com`), and the Better Auth sentinel client (`kv.better-auth.com/identify`). It also produces noisy console violations whenever a user has a content-injecting browser extension installed.
- Extends `script-src`, `connect-src`, `style-src`, `img-src`, and `font-src` in [vite.config.ts](vite.config.ts) to allow these legitimate sources plus the `chrome-extension:` and `moz-extension:` schemes.
- No directives were removed or loosened beyond adding specific origins; `default-src 'self'`, `object-src 'none'`, `frame-ancestors 'none'`, `base-uri 'self'`, `form-action 'self'`, and `upgrade-insecure-requests` are untouched.

## Changes by directive
- **script-src**: + `googletagmanager.com`, `analytics.ahrefs.com`, `static.cloudflareinsights.com`, `chrome-extension:`, `moz-extension:`
- **connect-src**: + `kv.better-auth.com`, `www.google-analytics.com`, `*.analytics.google.com`, `analytics.ahrefs.com`, `cloudflareinsights.com`, `chrome-extension:`, `moz-extension:`
- **style-src / img-src / font-src**: + `chrome-extension:`, `moz-extension:`

## Test plan
- [ ] `pnpm dev` — load the app and confirm DevTools Console has no `Refused to … Content Security Policy` errors for the four flagged resources.
- [ ] Network tab: `beacon.min.js`, `gtag/js`, `ahrefs analytics.js`, `kv.better-auth.com/identify` all return non-blocked responses.
- [ ] Sanity check that previously working integrations still work: Sentry, egdata API, YouTube trailer iframes, fonts from `cdn.egdata.app`.
- [ ] With a content-injecting extension installed (ad blocker, password manager), reload — no `chrome-extension:` CSP errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)