### PR TITLE
fix(navbar): show top seller in Browse hover card

### DIFF
--- a/src/queries/top-section.ts
+++ b/src/queries/top-section.ts
@@ -9,9 +9,10 @@ type TopSection = {
 };
 
 export const getTopSection = async (slug: string) => {
+  // API off-by-one: `limit=N` returns N-1 elements, so `limit=1` returns 0.
   return httpClient.get<TopSection>(`/offers/${slug}`, {
     params: {
-      limit: 1,
+      limit: 2,
     },
   });
 };


### PR DESCRIPTION
## Summary
- The Browse hover card in the navbar showed an empty right-side panel where the current top-selling game should appear. The request succeeded (HTTP 200) but `elements` came back empty, so the rendered card was silently skipped.
- Root cause is an off-by-one in the egdata.app API: `/offers/{slug}?limit=N` returns `N-1` elements (`limit=1` → 0, `limit=2` → 1, `limit=5` → 4, ...). `getTopSection` hardcoded `limit=1`, so `data.elements[0]` was always `undefined`.
- Client-side workaround: request `limit=2` in `getTopSection`. The navbar already reads only `elements[0]`, so no callsite changes. Comment added so the next reader doesn't "fix" it back to `1`.
- Underlying API bug should be addressed server-side in `api.egdata.app`; this PR is a small, contained client workaround.

## Test plan
- [x] `pnpm dev`, open http://localhost:3000
- [x] Hover the "Browse" navbar item — right-side card displays a top-selling game (image, title, "Top Seller on the Epic Games Store" caption)
- [x] DevTools → Network: `GET /offers/top-sellers?limit=2` returns 200 with `elements.length === 1`
- [x] Click the card → navigates to the corresponding `/offers/{id}` page

🤖 Generated with [Claude Code](https://claude.com/claude-code)