### PR TITLE
Expand E2E coverage for core public flows

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,7 +22,7 @@ jobs:
       uses: pnpm/action-setup@v4
         
     - name: Install dependencies
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
       
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps

--- a/src/components/app/game-card.tsx
+++ b/src/components/app/game-card.tsx
@@ -26,6 +26,7 @@ export function GameCard({
         params={{ id: game.id }}
         className="w-96 relative select-none"
         preload="viewport"
+        aria-label={`Open offer ${game.title}`}
       >
         <Card className="w-72 lg:max-w-sm rounded-lg overflow-hidden shadow-lg">
           <Image
@@ -85,7 +86,13 @@ export function OfferListItem({
   });
 
   return (
-    <Link to="/offers/$id" params={{ id: game.id }} className="w-full" preload="viewport">
+    <Link
+      to="/offers/$id"
+      params={{ id: game.id }}
+      className="w-full"
+      preload="viewport"
+      aria-label={`Open offer ${game.title}`}
+    >
       <Card className="flex flex-row w-full bg-card text-white p-2 rounded-lg h-fit relative">
         {/* Image Section */}
         <div className="flex-shrink-0 w-72 h-auto inline-flex items-center justify-center relative">

--- a/src/components/app/offer-card.tsx
+++ b/src/components/app/offer-card.tsx
@@ -26,7 +26,12 @@ export function GameCard({ offer }: { offer: SingleOffer }) {
   const isFree = offer.price?.price.discountPrice === 0;
 
   return (
-    <Link to="/offers/$id" params={{ id: offer.id }} preload="viewport">
+    <Link
+      to="/offers/$id"
+      params={{ id: offer.id }}
+      preload="viewport"
+      aria-label={`Open offer ${offer.title}`}
+    >
       <Card className="w-full max-w-sm rounded-lg overflow-hidden shadow-lg relative">
         <CardHeader className="p-0 rounded-t-xl relative">
           <Image
@@ -265,6 +270,7 @@ export function OfferCard({
       preload="viewport"
       className="select-none group mx-auto w-fit md:w-full"
       viewTransition
+      aria-label={`Open offer ${offer.title}`}
     >
       <Card className="w-64 md:w-full overflow-hidden rounded-lg border-0 relative">
         <Image

--- a/src/components/modules/mobile-freebies.tsx
+++ b/src/components/modules/mobile-freebies.tsx
@@ -47,6 +47,7 @@ export function MobileFreebiesCarousel() {
           variant="outline"
           className="h-9 w-9 p-0"
           onClick={() => setIsExpanded(!isExpanded)}
+          aria-label={isExpanded ? "Collapse mobile free games" : "Expand mobile free games"}
         >
           <ArrowDown
             className={cn("h-5 w-5 m-2 transition-transform ease-in-out duration-300", {

--- a/src/components/search/SearchHeader.tsx
+++ b/src/components/search/SearchHeader.tsx
@@ -78,7 +78,7 @@ export function SearchHeader(props: SearchHeaderProps) {
               value={query.sortBy ?? undefined}
               onValueChange={(value) => setField("sortBy", value as typeof query.sortBy)}
             >
-              <SelectTrigger className="w-[180px]">
+              <SelectTrigger className="w-[180px]" aria-label="Sort offers">
                 <SelectValue placeholder="Sort by" />
               </SelectTrigger>
               <SelectContent>
@@ -93,6 +93,7 @@ export function SearchHeader(props: SearchHeaderProps) {
               onClick={() => setField("sortDir", query.sortDir === "asc" ? "desc" : "asc")}
               variant="outline"
               className="w-9"
+              aria-label="Toggle sort direction"
             >
               <ArrowDown
                 className={cn(
@@ -108,6 +109,7 @@ export function SearchHeader(props: SearchHeaderProps) {
             variant="outline"
             className="h-9 w-9 p-0 hidden md:flex"
             onClick={() => setView(view === "grid" ? "list" : "grid")}
+            aria-label={view === "grid" ? "Show list view" : "Show grid view"}
           >
             {view === "grid" ? (
               <ListBulletIcon className="h-5 w-5" aria-hidden="true" />

--- a/tests/e2e/freebies.spec.ts
+++ b/tests/e2e/freebies.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+import {
+  expectMainReady,
+  expectSearchResultsReady,
+  waitForSearchResponse,
+} from "./support/assertions";
+
+test.describe("Freebies flow", () => {
+  test("renders stats, current freebies, mobile freebies, and past freebies search", async ({
+    page,
+  }) => {
+    const initialSearch = waitForSearchResponse(page);
+    await page.goto("/freebies");
+    await initialSearch;
+
+    await expectMainReady(page);
+    await expect(page.getByRole("heading", { name: "Giveaways in numbers" })).toBeVisible();
+    await expect(page.getByText("Total Value")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Current Free Games" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Redeem Now" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Mobile Free Games" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Past Free Games" })).toBeVisible();
+    await expectSearchResultsReady(page);
+
+    await Promise.all([
+      waitForSearchResponse(page),
+      page.getByPlaceholder("Search for games").fill("lego"),
+    ]);
+    await expect(page).toHaveURL(/title=lego/);
+    await expect(page).toHaveURL(/pastGiveaways=true/);
+    await expect(page).toHaveURL(/sortBy=giveawayDate/);
+    await expectSearchResultsReady(page);
+  });
+
+  for (const legacyPath of ["/free-games", "/freegames"]) {
+    test(`redirects ${legacyPath} to /freebies`, async ({ page }) => {
+      await page.goto(legacyPath);
+      await expect(page).toHaveURL(/\/freebies\/?$/);
+      await expectMainReady(page);
+    });
+  }
+});

--- a/tests/e2e/homepage.spec.ts
+++ b/tests/e2e/homepage.spec.ts
@@ -1,20 +1,38 @@
 import { expect, test } from "@playwright/test";
+import { expectMainReady, expectNoAppError } from "./support/assertions";
 
 test.describe("Homepage smoke", () => {
-  test("renders homepage shell", async ({ page }) => {
+  test("renders homepage content and key sections", async ({ page }) => {
     await page.goto("/");
+    await expectMainReady(page);
+
     await expect(page.getByRole("heading", { name: "egdata.app", exact: true })).toBeVisible();
-    await expect(page.locator("main")).toBeVisible();
+    await expect(page.getByText("Track prices, discover deals")).toBeVisible();
+    await expect(page.getByPlaceholder("Search offers, items, or sellers...")).toBeVisible();
+
+    await expect(page.getByText("Offers Tracked")).toBeVisible();
+    await expect(page.getByText("Price Changes / 72h")).toBeVisible();
+    await expect(page.getByText("Active Discounts")).toBeVisible();
+    await expect(page.getByText("Giveaways to Date")).toBeVisible();
+
+    await expect(page.getByRole("link", { name: "Giveaway Stats", exact: true })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Giveaway Offers", exact: true })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Latest Offers", exact: true })).toBeVisible();
+    await expectNoAppError(page);
   });
 
   test("navigates to key routes from homepage links", async ({ page }) => {
     await page.goto("/");
+    await expectMainReady(page);
 
     await page.getByRole("link", { name: "Giveaway Stats", exact: true }).click();
     await expect(page).toHaveURL(/\/freebies/);
+    await expectMainReady(page);
 
     await page.goto("/");
+    await expectMainReady(page);
     await page.getByRole("link", { name: "Latest Offers", exact: true }).click();
     await expect(page).toHaveURL(/\/search\?sortBy=creationDate/);
+    await expectMainReady(page);
   });
 });

--- a/tests/e2e/offers.spec.ts
+++ b/tests/e2e/offers.spec.ts
@@ -1,14 +1,65 @@
 import { expect, test } from "@playwright/test";
+import {
+  expectMainReady,
+  expectNoAppError,
+  expectSearchResultsReady,
+  waitForSearchResponse,
+} from "./support/assertions";
 
-const routes = ["/search", "/freebies", "/about", "/offers/non-existent-offer-id-12345"];
+test.describe("Offer detail flow", () => {
+  test("opens an offer from search and navigates detail tabs", async ({ page }) => {
+    const initialSearch = waitForSearchResponse(page);
+    await page.goto("/search?sortBy=creationDate");
+    await initialSearch;
 
-test.describe("Route smoke", () => {
-  for (const route of routes) {
-    test(`renders ${route}`, async ({ page }) => {
-      await page.goto(route);
-      await expect(page).toHaveURL(new RegExp(`${route.replace("/", "\\/")}`));
-      await expect(page.locator("main")).toBeVisible();
-      await expect(page.getByText(/Application error|ReferenceError|TypeError/i)).toHaveCount(0);
-    });
-  }
+    await expectMainReady(page);
+    await expectSearchResultsReady(page);
+
+    const firstOffer = page.getByRole("link", { name: /^Open offer / }).first();
+    await expect(firstOffer).toBeVisible();
+    const offerName = (await firstOffer.getAttribute("aria-label"))?.replace(/^Open offer /, "");
+
+    await Promise.all([page.waitForURL(/\/offers\/[^/?#]+\/?$/), firstOffer.click()]);
+
+    await expectMainReady(page);
+    await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible();
+    if (offerName) {
+      await expect(page.getByRole("heading", { name: offerName, level: 1 })).toBeVisible();
+    }
+    await expect(page.getByText("Offer ID")).toBeVisible();
+    await expect(page.getByText("Namespace")).toBeVisible();
+    await expect(page.getByText("Seller").first()).toBeVisible();
+
+    const tabHeadings: Record<string, RegExp> = {
+      Price: /^Price$/,
+      Items: /^Items$/,
+      Changelog: /^Changelog$/,
+      Reviews: /Epic Players Rating|EGDATA Rating|Critic Reviews/,
+    };
+
+    const offerInformation = page.locator("#offer-information").first();
+    for (const [tab, heading] of Object.entries(tabHeadings)) {
+      await Promise.all([
+        page.waitForURL(new RegExp(`/offers/[^/]+/${tab.toLowerCase()}`)),
+        offerInformation.getByRole("link", { name: tab, exact: true }).click(),
+      ]);
+      await expect(page.getByRole("heading", { name: heading }).first()).toBeVisible({
+        timeout: 30_000,
+      });
+      await expectNoAppError(page);
+    }
+  });
+
+  test("renders a clear not-found state for an invalid offer", async ({ page }) => {
+    await page.goto("/offers/non-existent-offer-id-12345");
+    await expect(page).toHaveURL(/\/offers\/non-existent-offer-id-12345/);
+    await expect(page.locator("main")).toContainText("Offer not found");
+    await expectNoAppError(page);
+  });
+
+  test("renders static informational route", async ({ page }) => {
+    await page.goto("/about");
+    await expect(page).toHaveURL(/\/about/);
+    await expectMainReady(page);
+  });
 });

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+import {
+  expectMainReady,
+  expectSearchResultsReady,
+  waitForSearchResponse,
+} from "./support/assertions";
+
+test.describe("Search flow", () => {
+  test("loads results and keeps filters in the URL", async ({ page }) => {
+    const initialSearch = waitForSearchResponse(page);
+    await page.goto("/search");
+    await initialSearch;
+
+    await expectMainReady(page);
+    await expect(page.getByRole("heading", { name: "Search", exact: true })).toBeVisible();
+    await expectSearchResultsReady(page);
+
+    await Promise.all([
+      waitForSearchResponse(page),
+      page.getByPlaceholder("Search for games").fill("fortnite"),
+    ]);
+    await expect(page).toHaveURL(/title=fortnite/);
+    await expectSearchResultsReady(page);
+
+    await Promise.all([
+      waitForSearchResponse(page),
+      page.getByRole("checkbox", { name: "On Sale" }).click(),
+    ]);
+    await expect(page).toHaveURL(/onSale=true/);
+    await expectSearchResultsReady(page);
+
+    await page.getByRole("combobox", { name: "Sort offers" }).click();
+    await Promise.all([
+      waitForSearchResponse(page),
+      page.getByRole("option", { name: "Price" }).click(),
+    ]);
+    await expect(page).toHaveURL(/sortBy=price/);
+    await expectSearchResultsReady(page);
+  });
+});

--- a/tests/e2e/support/assertions.ts
+++ b/tests/e2e/support/assertions.ts
@@ -1,0 +1,49 @@
+import { expect, type Page } from "@playwright/test";
+
+const appErrorText =
+  /Application error|ReferenceError|TypeError|Cannot read properties|Hydration failed|Minified React error|Unhandled Runtime Error/i;
+
+export async function expectNoAppError(page: Page) {
+  await expect(page.getByText(appErrorText)).toHaveCount(0);
+}
+
+export async function expectMainReady(page: Page) {
+  await expect(page.locator("main").first()).toBeVisible({ timeout: 30_000 });
+  await expectNoAppError(page);
+}
+
+export async function waitForApiResponse(
+  page: Page,
+  urlPart: string | RegExp,
+  options: {
+    method?: string;
+    timeout?: number;
+  } = {},
+) {
+  const response = await page.waitForResponse(
+    (res) => {
+      const matches =
+        typeof urlPart === "string" ? res.url().includes(urlPart) : urlPart.test(res.url());
+      const methodMatches =
+        !options.method || res.request().method().toUpperCase() === options.method.toUpperCase();
+
+      return matches && methodMatches;
+    },
+    { timeout: options.timeout ?? 20_000 },
+  );
+
+  expect(response.status(), `${response.request().method()} ${response.url()}`).toBeLessThan(500);
+
+  return response;
+}
+
+export async function waitForSearchResponse(page: Page) {
+  return waitForApiResponse(page, "/search/v2/search", { method: "POST" });
+}
+
+export async function expectSearchResultsReady(page: Page) {
+  await expect(
+    page.getByRole("link", { name: /^Open offer / }).first().or(page.getByText("No results found")),
+  ).toBeVisible({ timeout: 30_000 });
+  await expectNoAppError(page);
+}


### PR DESCRIPTION
## Summary
- Expanded Playwright coverage from basic route smoke tests to real user journeys across homepage, search, freebies, and offer detail pages.
- Added shared E2E helpers for main-page readiness, app error checks, and search API waits.
- Added minimal accessibility labels on interactive controls and offer links to keep selectors stable.
- Tightened CI install behavior by switching the E2E workflow to `pnpm install --frozen-lockfile`.

## Testing
- `pnpm build`
- `pnpm test:e2e`
- `pnpm typecheck`
- `pnpm exec oxlint src tests/e2e`