### PR TITLE
Allow Epic media CDN in the CSP media source list

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
               "img-src 'self' data: blob: https: chrome-extension: moz-extension:",
               "font-src 'self' data: https://cdn.egdata.app chrome-extension: moz-extension:",
               "connect-src 'self' https://api.egdata.app https://cdn.egdata.app https://analytics.egdata.app https://insights.egdata.app https://*.sentry.io https://*.ingest.sentry.io https://kv.better-auth.com https://www.google-analytics.com https://*.analytics.google.com https://analytics.ahrefs.com https://cloudflareinsights.com chrome-extension: moz-extension:",
-              "media-src 'self' https://cdn.egdata.app https://cdn1.epicgames.com",
+              "media-src 'self' https://cdn.egdata.app https://cdn1.epicgames.com https://media-cdn.epicgames.com",
               "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com",
               "worker-src 'self' blob:",
               "manifest-src 'self'",


### PR DESCRIPTION
## Summary
- Added `https://media-cdn.epicgames.com` to the `media-src` Content Security Policy in `vite.config.ts`
- Fixes blocked Epic `.webm` and other media assets served from the Epic media CDN

## Testing
- Not run (not requested)