### PR TITLE
Handle missing profile page param and add regression coverage

### DIFF
--- a/src/lib/build-image-url.ts
+++ b/src/lib/build-image-url.ts
@@ -1,9 +1,13 @@
 export type ImageQuality = "original" | "low" | "medium" | "high";
 
 const isAbsolute = (src: string) => src.startsWith("http") || src.startsWith("//");
+const shouldOptimize = (src: string) => isAbsolute(src) && !src.includes("/epic-achievements/");
 
-const buildImageUrl = (src: string, width: number, quality: ImageQuality = "medium") =>
-  isAbsolute(src) ? `${src}?w=${width}&quality=${quality}&resize=1` : "/placeholder.webp";
+const buildImageUrl = (src: string, width: number, quality: ImageQuality = "medium") => {
+  if (!isAbsolute(src)) return "/placeholder.webp";
+  if (!shouldOptimize(src)) return src;
+  return `${src}?w=${width}&quality=${quality}&resize=1`;
+};
 
 export default buildImageUrl;
 
@@ -14,7 +18,7 @@ export const buildSrcSet = (
   width: number,
   quality: ImageQuality = "medium",
 ): string | undefined => {
-  if (!isAbsolute(src)) return undefined;
+  if (!shouldOptimize(src)) return undefined;
   const widths = DPR_MULTIPLIERS
     .map((m) => Math.round(width * m))
     .filter((w, i, arr) => arr.indexOf(w) === i);

--- a/src/lib/build-image-url.ts
+++ b/src/lib/build-image-url.ts
@@ -6,12 +6,17 @@ const FALLBACK_BASE_URL = "https://egdata.app";
 
 const withImageParams = (src: string, width: number, quality: ImageQuality): string => {
   const isProtocolRelative = src.startsWith("//");
+  const srcToParse = isProtocolRelative ? `https:${src}` : src;
 
   let url: URL;
   try {
-    url = new URL(src);
+    url = new URL(srcToParse);
   } catch {
-    url = new URL(src, FALLBACK_BASE_URL);
+    try {
+      url = new URL(srcToParse, FALLBACK_BASE_URL);
+    } catch {
+      return src;
+    }
   }
 
   url.searchParams.set("w", String(width));

--- a/src/lib/build-image-url.ts
+++ b/src/lib/build-image-url.ts
@@ -2,19 +2,16 @@ export type ImageQuality = "original" | "low" | "medium" | "high";
 
 const isAbsolute = (src: string) => src.startsWith("http") || src.startsWith("//");
 const shouldOptimize = (src: string) => isAbsolute(src) && !src.includes("/epic-achievements/");
+const FALLBACK_BASE_URL = "https://egdata.app";
 
-const buildImageUrl = (src: string, width: number, quality: ImageQuality = "medium") => {
-  if (!isAbsolute(src)) return "/placeholder.webp";
-  if (!shouldOptimize(src)) return src;
-
+const withImageParams = (src: string, width: number, quality: ImageQuality): string => {
   const isProtocolRelative = src.startsWith("//");
-  const base = "https://egdata.app";
 
   let url: URL;
   try {
     url = new URL(src);
   } catch {
-    url = new URL(src, base);
+    url = new URL(src, FALLBACK_BASE_URL);
   }
 
   url.searchParams.set("w", String(width));
@@ -23,6 +20,12 @@ const buildImageUrl = (src: string, width: number, quality: ImageQuality = "medi
 
   const result = url.toString();
   return isProtocolRelative ? result.replace(/^https?:/, "") : result;
+};
+
+const buildImageUrl = (src: string, width: number, quality: ImageQuality = "medium") => {
+  if (!isAbsolute(src)) return "/placeholder.webp";
+  if (!shouldOptimize(src)) return src;
+  return withImageParams(src, width, quality);
 };
 
 export default buildImageUrl;
@@ -38,5 +41,5 @@ export const buildSrcSet = (
   const widths = DPR_MULTIPLIERS.map((m) => Math.round(width * m)).filter(
     (w, i, arr) => arr.indexOf(w) === i,
   );
-  return widths.map((w) => `${src}?w=${w}&quality=${quality}&resize=1 ${w}w`).join(", ");
+  return widths.map((w) => `${withImageParams(src, w, quality)} ${w}w`).join(", ");
 };

--- a/src/lib/build-image-url.ts
+++ b/src/lib/build-image-url.ts
@@ -6,7 +6,23 @@ const shouldOptimize = (src: string) => isAbsolute(src) && !src.includes("/epic-
 const buildImageUrl = (src: string, width: number, quality: ImageQuality = "medium") => {
   if (!isAbsolute(src)) return "/placeholder.webp";
   if (!shouldOptimize(src)) return src;
-  return `${src}?w=${width}&quality=${quality}&resize=1`;
+
+  const isProtocolRelative = src.startsWith("//");
+  const base = "https://egdata.app";
+
+  let url: URL;
+  try {
+    url = new URL(src);
+  } catch {
+    url = new URL(src, base);
+  }
+
+  url.searchParams.set("w", String(width));
+  url.searchParams.set("quality", quality);
+  url.searchParams.set("resize", "1");
+
+  const result = url.toString();
+  return isProtocolRelative ? result.replace(/^https?:/, "") : result;
 };
 
 export default buildImageUrl;
@@ -19,10 +35,8 @@ export const buildSrcSet = (
   quality: ImageQuality = "medium",
 ): string | undefined => {
   if (!shouldOptimize(src)) return undefined;
-  const widths = DPR_MULTIPLIERS
-    .map((m) => Math.round(width * m))
-    .filter((w, i, arr) => arr.indexOf(w) === i);
-  return widths
-    .map((w) => `${src}?w=${w}&quality=${quality}&resize=1 ${w}w`)
-    .join(", ");
+  const widths = DPR_MULTIPLIERS.map((m) => Math.round(width * m)).filter(
+    (w, i, arr) => arr.indexOf(w) === i,
+  );
+  return widths.map((w) => `${src}?w=${w}&quality=${quality}&resize=1 ${w}w`).join(", ");
 };

--- a/src/routes/profile/$id.tsx
+++ b/src/routes/profile/$id.tsx
@@ -684,7 +684,7 @@ function RefreshProfile({ id }: { id: string }) {
 
   return (
     <Tooltip delayDuration={0} open={refreshStatus?.canRefresh ? false : undefined}>
-      <TooltipTrigger>
+      <TooltipTrigger asChild>
         <Button
           variant="outline"
           onClick={handleRefresh}

--- a/src/routes/profile/$id/index.tsx
+++ b/src/routes/profile/$id/index.tsx
@@ -43,7 +43,7 @@ type RareAchievement = Achievement & {
 };
 
 const profileParamsSchema = z.object({
-  page: z.number().catch(1),
+  page: z.coerce.number().int().min(1).catch(1).default(1),
   platinum: z.boolean().optional(),
   sort: z.enum(["completion", "alphabetical", "xp", "achievements"]).optional(),
 });

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+import { expectNoAppError, waitForApiResponse } from "./support/assertions";
+
+const PROFILE_ID_WITH_ACHIEVEMENTS = "ac7b3a70e3ce4652b49c38e648001d9e";
+
+test.describe("Profile page", () => {
+  test("renders games with achievements without an explicit page search param", async ({
+    page,
+  }) => {
+    const gamesResponse = waitForApiResponse(
+      page,
+      `/profiles/${PROFILE_ID_WITH_ACHIEVEMENTS}/games`,
+    );
+
+    await page.goto(`/profile/${PROFILE_ID_WITH_ACHIEVEMENTS}`);
+
+    await gamesResponse;
+
+    await expect(page).toHaveURL(
+      new RegExp(`/profile/${PROFILE_ID_WITH_ACHIEVEMENTS}/?(?:\\?page=1)?$`),
+    );
+    await expect(page.getByRole("button", { name: "Overview" })).toBeVisible();
+    await expect(page.getByText("Achievements Progress").first()).toBeVisible({
+      timeout: 30_000,
+    });
+    await expectNoAppError(page);
+  });
+});

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -7,6 +7,26 @@ test.describe("Profile page", () => {
   test("renders games with achievements without an explicit page search param", async ({
     page,
   }) => {
+    const achievementIconRequests: string[] = [];
+    const invalidHtmlMessages: string[] = [];
+
+    page.on("console", (message) => {
+      if (message.type() !== "error" && message.type() !== "warning") return;
+
+      const text = message.text();
+      if (/cannot be a descendant|cannot contain a nested|hydration error/i.test(text)) {
+        invalidHtmlMessages.push(text);
+      }
+    });
+
+    page.on("request", (request) => {
+      const url = new URL(request.url());
+
+      if (url.pathname.includes("/epic-achievements/")) {
+        achievementIconRequests.push(request.url());
+      }
+    });
+
     const gamesResponse = waitForApiResponse(
       page,
       `/profiles/${PROFILE_ID_WITH_ACHIEVEMENTS}/games`,
@@ -23,6 +43,23 @@ test.describe("Profile page", () => {
     await expect(page.getByText("Achievements Progress").first()).toBeVisible({
       timeout: 30_000,
     });
+    const gameCardRarestAchievements = page
+      .locator(`a[href^="/profile/${PROFILE_ID_WITH_ACHIEVEMENTS}/achievements/"] section`, {
+        hasText: "Rarest Achievements",
+      })
+      .first();
+
+    await expect(gameCardRarestAchievements).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(gameCardRarestAchievements.locator("img").first()).toHaveAttribute(
+      "src",
+      /\/epic-achievements\/[^?]+$/,
+    );
     await expectNoAppError(page);
+
+    expect(achievementIconRequests.length).toBeGreaterThan(0);
+    expect(achievementIconRequests.filter((url) => new URL(url).search)).toEqual([]);
+    expect(invalidHtmlMessages).toEqual([]);
   });
 });

--- a/tests/e2e/support/assertions.ts
+++ b/tests/e2e/support/assertions.ts
@@ -1,7 +1,7 @@
 import { expect, type Page } from "@playwright/test";
 
 const appErrorText =
-  /Application error|ReferenceError|TypeError|Cannot read properties|Hydration failed|Minified React error|Unhandled Runtime Error/i;
+  /Application error|ReferenceError|TypeError|Cannot read properties|Hydration failed|Minified React error|Unhandled Runtime Error|ZodError|Invalid input: expected/i;
 
 export async function expectNoAppError(page: Page) {
   await expect(page.getByText(appErrorText)).toHaveCount(0);


### PR DESCRIPTION
## Summary
- Fix the profile achievements list search schema so a missing `page` param defaults cleanly instead of triggering a Zod validation error.
- Add a Playwright regression test that loads a real profile with achievements without `?page=` and verifies the games list renders.
- Expand the shared e2e app-error matcher to catch Zod validation failures.

## Testing
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec playwright test tests/e2e/profile.spec.ts --reporter=line`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalize missing/invalid profile page values to page 1 (coerced to integer, min 1).
  * Image optimization now skips achievement asset paths, preserves protocol-relative URLs, and returns a placeholder for non-absolute sources.

* **UI/UX Improvements**
  * Tooltip trigger now delegates behavior to its child button for profile refresh.

* **Tests**
  * Added Playwright e2e coverage for the Profile page and expanded error detection to include validation errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/egdata-app/egdata/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->