### PR TITLE
fix(csp): allow Google Analytics doubleclick collect endpoint

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
               "style-src 'self' 'unsafe-inline' https://cdn.egdata.app chrome-extension: moz-extension:",
               "img-src 'self' data: blob: https: chrome-extension: moz-extension:",
               "font-src 'self' data: https://cdn.egdata.app chrome-extension: moz-extension:",
-              "connect-src 'self' https://api.egdata.app https://cdn.egdata.app https://analytics.egdata.app https://insights.egdata.app https://*.sentry.io https://*.ingest.sentry.io https://kv.better-auth.com https://www.google-analytics.com https://*.analytics.google.com https://analytics.ahrefs.com https://cloudflareinsights.com chrome-extension: moz-extension:",
+              "connect-src 'self' https://api.egdata.app https://cdn.egdata.app https://analytics.egdata.app https://insights.egdata.app https://*.sentry.io https://*.ingest.sentry.io https://kv.better-auth.com https://www.google-analytics.com https://*.analytics.google.com https://stats.g.doubleclick.net https://analytics.ahrefs.com https://cloudflareinsights.com chrome-extension: moz-extension:",
               "media-src 'self' https://cdn.egdata.app https://cdn1.epicgames.com https://media-cdn.epicgames.com",
               "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com",
               "worker-src 'self' blob:",


### PR DESCRIPTION
### Motivation
- Google Analytics collection requests to `https://stats.g.doubleclick.net` were being blocked by the site's `Content-Security-Policy` `connect-src` directive, causing runtime CSP violations in the browser console.

### Description
- Added `https://stats.g.doubleclick.net` to the `connect-src` directive in the CSP headers in `vite.config.ts` so GA collect requests are permitted.

### Testing
- Ran `pnpm lint`, which completed successfully and reported only pre-existing warnings unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f27850ee8832088763ce53e56fcfd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated content security policy header configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/egdata-app/egdata/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->